### PR TITLE
Dynamic request buffer size for album info requests

### DIFF
--- a/artwork/artwork_internal.h
+++ b/artwork/artwork_internal.h
@@ -31,7 +31,7 @@
 
 #define FETCH_CONCURRENT_LIMIT 5
 
-size_t artwork_http_request(const char *url, char *buffer, const size_t max_bytes);
+const char* artwork_http_request (const char *url);
 
 void artwork_abort_all_http_requests (void);
 

--- a/artwork/lastfm.c
+++ b/artwork/lastfm.c
@@ -71,11 +71,13 @@ int fetch_from_lastfm (const char *artist, const char *album, char *dest, const 
     }
 
     trace("fetch_from_lastfm: query: %s\n", url);
-    char buffer[1000];
-    /*const size_t size = */artwork_http_request(url, buffer, sizeof(buffer));
+    const char* buffer = artwork_http_request(url);
 
-    free (url);
+    free(url);
     url = NULL;
+    
+    if (!buffer)
+        return -1;
 
     char *img = strstr(buffer, MEGA_IMAGE_TAG);
     if (img) {

--- a/artwork/request_buffer.h
+++ b/artwork/request_buffer.h
@@ -1,0 +1,7 @@
+#ifndef __REQUEST_BUFFER_H
+#define __REQUEST_BUFFER_H
+
+extern char *request_buffer;
+extern size_t request_buffer_size;
+
+#endif /*__REQUEST_BUFFER_H*/

--- a/discord_presence.c
+++ b/discord_presence.c
@@ -26,6 +26,10 @@
 #include <stdlib.h>
 #include "discord_rpc.h"
 #include "artwork/lastfm.h"
+#include "artwork/request_buffer.h"
+
+char* request_buffer = NULL;
+size_t request_buffer_size = 0;
 
 DB_misc_t plugin;
 //#define trace(...) { deadbeef->log ( __VA_ARGS__); }
@@ -338,7 +342,6 @@ discord_presence_start () {
             playback_resume_status = paused;
         }
     }
-
     return 0;
 }
 
@@ -348,6 +351,10 @@ discord_presence_stop () {
         Discord_Shutdown();
         discord_enabled = 0;
     }
+    
+    free(request_buffer);
+    request_buffer = NULL;
+    request_buffer_size = 0;
     return 0;
 }
 


### PR DESCRIPTION
A buffer size of 1000 wasn't enough to hold the response data of album info requests that were too long. Instead of making a normal buffer with a fixed size and hope that it fits, allocate a single dynamic buffer that's used throughout the lifetime of the plugin.